### PR TITLE
Fix directive import path

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,5 @@
 // directives
-import clickOutside from "@/directives/click-outside.js";
+import clickOutside from "./composables/click-outside.js";
 
 import { createApp } from "vue";
 import App from "./App.vue";


### PR DESCRIPTION
## Summary
- resolve `click-outside` directive directly from composables folder

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6849421da7dc83209b23deca4ab68261