### PR TITLE
Add SingleSelect component and variant

### DIFF
--- a/src/components/SingleSelect.vue
+++ b/src/components/SingleSelect.vue
@@ -1,0 +1,69 @@
+<template>
+  <div class="single-select">
+    <select v-model="selected" @change="emitSelection">
+      <option disabled value="">Select...</option>
+      <option
+        v-for="option in options"
+        :key="getOptionValue(option)"
+        :value="getOptionValue(option)"
+      >
+        {{ getLabel(option) }}
+      </option>
+    </select>
+  </div>
+</template>
+
+<script setup>
+import { ref, watch } from "vue";
+
+const props = defineProps({
+  options: { type: Array, default: () => [] },
+  modelValue: { type: [String, Number, Object], default: "" },
+  labelKey: { type: String, default: "label" },
+  valueKey: { type: String, default: "value" }
+});
+
+const emit = defineEmits(["update:modelValue"]);
+
+function getOptionValue(option) {
+  return typeof option === "object" ? option[props.valueKey] : option;
+}
+
+function getLabel(option) {
+  return typeof option === "object" ? option[props.labelKey] : option;
+}
+
+function getSelectedValue(val) {
+  if (val && typeof val === "object") {
+    return val[props.valueKey];
+  }
+  return val ?? "";
+}
+
+const selected = ref(getSelectedValue(props.modelValue));
+
+watch(
+  () => props.modelValue,
+  value => {
+    selected.value = getSelectedValue(value);
+  }
+);
+
+function emitSelection() {
+  const found = props.options.find(
+    option => String(getOptionValue(option)) === String(selected.value)
+  );
+  const toEmit = found
+    ? typeof found === "object"
+      ? found
+      : selected.value
+    : selected.value;
+  emit("update:modelValue", toEmit);
+}
+</script>
+
+<style scoped>
+.single-select select {
+  padding: 0.5rem;
+}
+</style>

--- a/src/components/variants/SingleSelectSimple.vue
+++ b/src/components/variants/SingleSelectSimple.vue
@@ -1,0 +1,29 @@
+<template>
+  <div class="single-select-variant">
+    <SingleSelect v-model="primitive" :options="primitiveOptions" />
+    <SingleSelect v-model="selectedObject" :options="objectOptions" />
+  </div>
+</template>
+
+<script setup>
+import { ref } from "vue";
+import SingleSelect from "../SingleSelect.vue";
+
+const primitiveOptions = ["Apple", "Banana", "Cherry"];
+const objectOptions = [
+  { label: "One", value: 1 },
+  { label: "Two", value: 2 },
+  { label: "Three", value: 3 }
+];
+
+const primitive = ref("Apple");
+const selectedObject = ref(objectOptions[0]);
+</script>
+
+<style scoped>
+.single-select-variant {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+</style>

--- a/tests/single-select-variant.test.js
+++ b/tests/single-select-variant.test.js
@@ -1,0 +1,13 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import Variant from "../src/components/variants/SingleSelectSimple.vue";
+
+describe("SingleSelect simple variant", () => {
+  it("renders two select elements with initial values", () => {
+    const wrapper = mount(Variant);
+    const selects = wrapper.findAll("select");
+    expect(selects.length).toBe(2);
+    expect(selects[0].element.value).toBe("Apple");
+    expect(selects[1].element.value).toBe("1");
+  });
+});

--- a/tests/single-select.test.js
+++ b/tests/single-select.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import SingleSelect from "../src/components/SingleSelect.vue";
+
+describe("SingleSelect Component", () => {
+  it("emits selected primitive value", async () => {
+    const wrapper = mount(SingleSelect, {
+      props: { options: ["a", "b", "c"] }
+    });
+
+    await wrapper.find("select").setValue("b");
+
+    expect(wrapper.emitted()["update:modelValue"][0]).toEqual(["b"]);
+  });
+
+  it("emits selected object", async () => {
+    const options = [
+      { label: "One", value: 1 },
+      { label: "Two", value: 2 }
+    ];
+    const wrapper = mount(SingleSelect, { props: { options } });
+
+    await wrapper.find("select").setValue("2");
+
+    expect(wrapper.emitted()["update:modelValue"][0]).toEqual([options[1]]);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `SingleSelect.vue` for simple single selections
- add `SingleSelectSimple` variant demonstrating primitive and object options
- create tests for component and variant

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6849739108c88320a83715d5207252ea